### PR TITLE
Fix unsafe call in Studioforty9_Recaptcha_Helper_Redirect

### DIFF
--- a/app/code/community/Studioforty9/Recaptcha/Helper/Redirect.php
+++ b/app/code/community/Studioforty9/Recaptcha/Helper/Redirect.php
@@ -64,9 +64,9 @@ class Studioforty9_Recaptcha_Helper_Redirect extends Mage_Core_Helper_Abstract
             return $referer;
     	}
 
-    	if ($this->_session->hasLastUrl()) {
-    		return $this->_session->getLastUrl();
-    	}
+    	if ($this->getSession()->hasLastUrl()) {
+		return $this->getSession()->getLastUrl();
+	}
 
     	return $this->getRequestUri();
     }


### PR DESCRIPTION
I was testing a custom route for this module using CLI curl and stumbled upon this error:

`Call to a member function hasLastUrl() on null in app/code/community/Studioforty9/Recaptcha/Helper/Redirect.php on line 67.`