### PR TITLE
Use layout template if defined

### DIFF
--- a/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
+++ b/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
@@ -26,7 +26,7 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
         'ca_ES' => 'ca',
         'zh_CN' => 'zh-CN',
         'zh_HK|zh_TW' => 'zh-TW',
-        'hr_HR' => 'hr',
+        'hr_HR' => 'hr', 
         'cs_CZ' => 'cs',
         'da_DK' => 'da',
         'nl_NL' => 'nl',
@@ -132,7 +132,7 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
      *
      * @return string
      */
-    public function getRecaptchaScript()
+    public function getRecaptchaScript($id)
     {
         if (! $this->_getHelper()->isEnabled()) {
             return '';
@@ -148,7 +148,7 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
         }
 
         $query = array(
-            'onload' => 'onloadCallback',
+            'onload' => 'onloadCallback'.$id,
             'render' => 'explicit',
             'hl'     => $lang
         );

--- a/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
+++ b/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
@@ -144,6 +144,8 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
 
     /**
      * Get the reCAPTACHA javascript code.
+     * This is only for reCaptcha V2. The method name does not specify it for BC reasons.
+     * For reCaptcha V3 the getRecaptchaV3ScriptUrl() method should be used.
      *
      * @return string
      */
@@ -153,11 +155,20 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
             return '';
         }
 
-        if ($this->_getHelper()->getVersion() === 3) {
-            return $this->getRecaptchaScriptV3();
-        }
-
         return $this->getRecaptchaScriptV2($id);
+    }
+
+    public function getRecaptchaV3ScriptUrl(): string
+    {
+        $siteKey = $this->getSiteKey();
+        $id = $this->getRecaptchaId();
+
+        $query = [
+            'render' => $siteKey,
+            'onload' => sprintf('recaptchaOnloadCallback_%s', $id)
+        ];
+
+        return sprintf('https://www.google.com/recaptcha/api.js?%s', http_build_query($query));
     }
 
     /**
@@ -221,15 +232,5 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
             '<script src="https://www.google.com/recaptcha/api.js?%s" async defer></script>',
             http_build_query($query)
         );
-    }
-
-    private function getRecaptchaScriptV3(): string
-    {
-        $siteKey = $this->getSiteKey();
-        $id = $this->getRecaptchaId();
-
-        return <<<HTML
-<script async src="https://www.google.com/recaptcha/api.js?render=$siteKey&onload=recaptchaOnloadCallback_$id"></script>
-HTML;
     }
 }

--- a/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
+++ b/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
@@ -102,6 +102,9 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
      */
     public function getTheme()
     {
+        if ($this->hasData('theme')) {
+            return $this->getData('theme');
+        }
         return $this->_getHelper()->getTheme();
     }
 

--- a/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
+++ b/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
@@ -26,7 +26,7 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
         'ca_ES' => 'ca',
         'zh_CN' => 'zh-CN',
         'zh_HK|zh_TW' => 'zh-TW',
-        'hr_HR' => 'hr', 
+        'hr_HR' => 'hr',
         'cs_CZ' => 'cs',
         'da_DK' => 'da',
         'nl_NL' => 'nl',
@@ -67,6 +67,18 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
         'uk_UA' => 'uk',
         'vi_VN' => 'vi'
     );
+
+    /**
+     * @var string
+     */
+    private $recaptchaId;
+
+    protected function _construct()
+    {
+        parent::_construct();
+        $this->recaptchaId = uniqid();
+    }
+
 
     /**
      * Is the block allowed to display.
@@ -141,6 +153,55 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
             return '';
         }
 
+        if ($this->_getHelper()->getVersion() === 3) {
+            return $this->getRecaptchaScriptV3();
+        }
+
+        return $this->getRecaptchaScriptV2($id);
+    }
+
+    /**
+     * Get a unique ID for the recaptcha block.
+     *
+     * @return string
+     */
+    public function getRecaptchaId()
+    {
+        return $this->recaptchaId;
+    }
+
+    public function getTemplate()
+    {
+        if ($this->_getHelper()->getVersion() === 3) {
+            return 'studioforty9/recaptcha/v3.phtml';
+        }
+
+        return 'studioforty9/recaptcha/explicit.phtml';
+    }
+
+
+    /**
+     * Get the recaptcha helper.
+     *
+     * @return Studioforty9_Recaptcha_Helper_Data
+     */
+    protected function _getHelper()
+    {
+        return Mage::helper('studioforty9_recaptcha');
+    }
+
+    protected function _toHtml()
+    {
+        if (!$this->_getHelper()->isEnabled()) {
+            return '';
+        }
+
+        return parent::_toHtml();
+    }
+
+
+    private function getRecaptchaScriptV2($id): string
+    {
         $language = Mage::app()->getLocale()->getLocale()->toString();
         $lang = 'en';
 
@@ -151,9 +212,9 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
         }
 
         $query = array(
-            'onload' => 'onloadCallback'.$id,
+            'onload' => 'onloadCallback' . $id,
             'render' => 'explicit',
-            'hl'     => $lang
+            'hl' => $lang
         );
 
         return sprintf(
@@ -162,23 +223,13 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
         );
     }
 
-    /**
-     * Get a unique ID for the recaptcha block.
-     *
-     * @return string
-     */
-    public function getRecaptchaId()
+    private function getRecaptchaScriptV3(): string
     {
-        return uniqid();
-    }
+        $siteKey = $this->getSiteKey();
+        $id = $this->getRecaptchaId();
 
-    /**
-     * Get the recaptcha helper.
-     *
-     * @return Studioforty9_Recaptcha_Helper_Data
-     */
-    protected function _getHelper()
-    {
-        return Mage::helper('studioforty9_recaptcha');
+        return <<<HTML
+<script async src="https://www.google.com/recaptcha/api.js?render=$siteKey&onload=recaptchaOnloadCallback_$id"></script>
+HTML;
     }
 }

--- a/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
+++ b/app/code/community/Studioforty9/Recaptcha/Block/Explicit.php
@@ -183,7 +183,7 @@ class Studioforty9_Recaptcha_Block_Explicit extends Mage_Core_Block_Template
 
     public function getTemplate()
     {
-        if ($this->_getHelper()->getVersion() === 3) {
+        if ($this->_getHelper()->getVersion() === '3') {
             return 'studioforty9/recaptcha/v3.phtml';
         }
 

--- a/app/code/community/Studioforty9/Recaptcha/Helper/Data.php
+++ b/app/code/community/Studioforty9/Recaptcha/Helper/Data.php
@@ -163,9 +163,9 @@ class Studioforty9_Recaptcha_Helper_Data extends Mage_Core_Helper_Abstract
             ->is('active', 'true');
     }
 
-    public function getVersion(): int
+    public function getVersion(): string
     {
-        return (int)Mage::getStoreConfig(self::MODULE_VERSION);
+        return (string)Mage::getStoreConfig(self::MODULE_VERSION);
     }
 
     public function getScoreThreshold(): float

--- a/app/code/community/Studioforty9/Recaptcha/Helper/Data.php
+++ b/app/code/community/Studioforty9/Recaptcha/Helper/Data.php
@@ -32,6 +32,8 @@ class Studioforty9_Recaptcha_Helper_Data extends Mage_Core_Helper_Abstract
     const MODULE_KEY_SIZE = 'google/recaptcha/size';
     const MODULE_KEY_TYPE = 'google/recaptcha/type';
     const MODULE_KEY_ROUTES = 'google/recaptcha/enabled_routes';
+    const MODULE_VERSION = 'google/recaptcha/version';
+    const MODULE_SCORE_THRESHOLD = 'google/recaptcha/score_threshold';
     /**#@-*/
 
     /**
@@ -110,7 +112,7 @@ class Studioforty9_Recaptcha_Helper_Data extends Mage_Core_Helper_Abstract
     {
         $routes = array_filter(explode(',', Mage::getStoreConfig(self::MODULE_KEY_ROUTES)));
         array_map('strtolower', $routes);
-        
+
         return $routes;
     }
 
@@ -144,10 +146,10 @@ class Studioforty9_Recaptcha_Helper_Data extends Mage_Core_Helper_Abstract
         if (! $this->isModuleActive() || ! $this->isEnabled()) {
             return false;
         }
-        
+
         return $this->isEnabledRoute($route);
     }
-		
+
     /**
      * Is the module active.
      *
@@ -159,5 +161,15 @@ class Studioforty9_Recaptcha_Helper_Data extends Mage_Core_Helper_Abstract
         return Mage::getConfig()
             ->getModuleConfig("Studioforty9_Recaptcha")
             ->is('active', 'true');
+    }
+
+    public function getVersion(): int
+    {
+        return (int)Mage::getStoreConfig(self::MODULE_VERSION);
+    }
+
+    public function getScoreThreshold(): float
+    {
+        return (float)Mage::getStoreConfig(self::MODULE_SCORE_THRESHOLD);
     }
 }

--- a/app/code/community/Studioforty9/Recaptcha/Helper/Redirect.php
+++ b/app/code/community/Studioforty9/Recaptcha/Helper/Redirect.php
@@ -64,8 +64,8 @@ class Studioforty9_Recaptcha_Helper_Redirect extends Mage_Core_Helper_Abstract
             return $referer;
     	}
 
-    	if ($this->_session->hasLastUrl()) {
-    		return $this->_session->getLastUrl();
+        if ($this->getSession()->hasLastUrl()) {
+            return $this->getSession()->getLastUrl();
     	}
 
     	return $this->getRequestUri();
@@ -105,7 +105,7 @@ class Studioforty9_Recaptcha_Helper_Redirect extends Mage_Core_Helper_Abstract
      */
     protected function getRequestUri()
     {
-    	$visitorData = $this->_session->getData('visitor_data');
+        $visitorData = $this->getSession()->getData('visitor_data');
 
     	return ($this->hasRequestUri($visitorData)) ? $visitorData['request_uri'] : Mage::getBaseUrl();
     }

--- a/app/code/community/Studioforty9/Recaptcha/Helper/Request.php
+++ b/app/code/community/Studioforty9/Recaptcha/Helper/Request.php
@@ -11,6 +11,8 @@
  * @link      https://github.com/studioforty9/recaptcha
  */
 
+use ReCaptcha\ReCaptcha;
+
 /**
  * Studioforty9_Recaptcha_Helper_Request
  *
@@ -21,43 +23,7 @@
  */
 class Studioforty9_Recaptcha_Helper_Request extends Mage_Core_Helper_Abstract
 {
-    const REQUEST_URL = 'https://www.google.com/recaptcha/api/siteverify';
     const REQUEST_RESPONSE = 'g-recaptcha-response';
-
-    /**
-     * @var Varien_Http_Client $_client
-     */
-    protected $_client;
-
-    /**
-     * Set the client to make the request to recaptca.
-     *
-     * @param Varien_Http_Client $client The http client to use
-     *
-     * @return $this
-     */
-    public function setHttpClient(Varien_Http_Client $client)
-    {
-        $this->_client = $client;
-        
-        return $this;
-    }
-
-    /**
-     * Get the Http Client to use for the request to reCAPTCHA
-     *
-     * @return Zend_Http_Client
-     */
-    public function getHttpClient()
-    {
-        if (is_null($this->_client)) {
-            $this->_client = new Zend_Http_Client();
-        }
-        
-        $this->_client->setUri(self::REQUEST_URL);
-
-        return $this->_client;
-    }
 
     /**
      * Verify the details of the recaptcha request.
@@ -66,29 +32,19 @@ class Studioforty9_Recaptcha_Helper_Request extends Mage_Core_Helper_Abstract
      */
     public function verify()
     {
-        $params = array(
-            'secret'   => $this->_getHelper()->getSecretKey(),
-            'response' => $this->_getRequest()->getPost(self::REQUEST_RESPONSE),
-            'remoteip' => $this->_getRequest()->getClientIp(true),
-        );
-        
-        $client = $this->getHttpClient();
-        $client->setParameterPost($params);
-        $errors = array();
+        $secret = $this->_getHelper()->getSecretKey();
+        $version = $this->_getHelper()->getVersion();
+        $scoreThreshold = $this->_getHelper()->getScoreThreshold();
+        $remoteIp = $this->_getRequest()->getClientIp();
+        $gRecaptchaResponse = $this->_getRequest()->getPost(self::REQUEST_RESPONSE);
 
-        try {
-            $response = $client->request('POST');
-            $body = $response->getBody();
-            $data = Mage::helper('core')->jsonDecode($body);
-            if (array_key_exists('error-codes', $data)) {
-                $errors = $data['error-codes'];
-            }
-        } catch (Exception $e) {
-            Mage::logException($e);
-            $data = array('success' => false);
+        $recaptcha = new ReCaptcha($secret);
+        if ($version === 3) {
+            $recaptcha->setScoreThreshold($scoreThreshold);
         }
+        $response = $recaptcha->verify($gRecaptchaResponse, $remoteIp);
 
-        return new Studioforty9_Recaptcha_Helper_Response($data['success'], $errors);
+        return new Studioforty9_Recaptcha_Helper_Response($response->isSuccess(), $response->getErrorCodes());
     }
 
     /**
@@ -97,7 +53,7 @@ class Studioforty9_Recaptcha_Helper_Request extends Mage_Core_Helper_Abstract
      * @codeCoverageIgnore
      * @return Studioforty9_Recaptcha_Helper_Data
      */
-    protected function _getHelper()
+    private function _getHelper()
     {
         return Mage::helper('studioforty9_recaptcha');
     }

--- a/app/code/community/Studioforty9/Recaptcha/Helper/Request.php
+++ b/app/code/community/Studioforty9/Recaptcha/Helper/Request.php
@@ -23,7 +23,7 @@ use ReCaptcha\ReCaptcha;
  */
 class Studioforty9_Recaptcha_Helper_Request extends Mage_Core_Helper_Abstract
 {
-    const REQUEST_RESPONSE = 'g-recaptcha-response';
+    public const REQUEST_RESPONSE = 'g-recaptcha-response';
 
     /**
      * Verify the details of the recaptcha request.

--- a/app/code/community/Studioforty9/Recaptcha/Helper/Request.php
+++ b/app/code/community/Studioforty9/Recaptcha/Helper/Request.php
@@ -39,7 +39,7 @@ class Studioforty9_Recaptcha_Helper_Request extends Mage_Core_Helper_Abstract
         $gRecaptchaResponse = $this->_getRequest()->getPost(self::REQUEST_RESPONSE);
 
         $recaptcha = new ReCaptcha($secret);
-        if ($version === 3) {
+        if ($version === '3') {
             $recaptcha->setScoreThreshold($scoreThreshold);
         }
         $response = $recaptcha->verify($gRecaptchaResponse, $remoteIp);

--- a/app/code/community/Studioforty9/Recaptcha/Model/Observer.php
+++ b/app/code/community/Studioforty9/Recaptcha/Model/Observer.php
@@ -43,28 +43,32 @@ class Studioforty9_Recaptcha_Model_Observer
         if ($response->isSuccess()) return;
         
         /** reCAPTCHA Verification Failed **/
-        
-        Mage::getSingleton('core/session')->addError(
-            Mage::helper('studioforty9_recaptcha')->__(
-                'There was an error with the recaptcha code, please try again.'
-            )
+
+        $errorMessage = Mage::helper('studioforty9_recaptcha')->__(
+            'There was an error with the recaptcha code, please try again.'
         );
-        
-        $flag = Mage_Core_Controller_Varien_Action::FLAG_NO_DISPATCH;
-        $redirectUrl = Mage::helper('studioforty9_recaptcha/redirect')->getUrl();
 
         $controller->getRequest()->setDispatched(true);
-        $controller->setFlag('', $flag, true);
-        $controller->getResponse()->setRedirect($redirectUrl);
-        
+        $controller->setFlag('', Mage_Core_Controller_Varien_Action::FLAG_NO_DISPATCH, true);
+
+        if ($controller->getRequest()->isAjax()) {
+            $controller->getResponse()->setHttpResponseCode(400);
+            $controller->getResponse()->setBody($errorMessage);
+        } else {
+            Mage::getSingleton('core/session')->addError($errorMessage);
+
+            $redirectUrl = Mage::helper('studioforty9_recaptcha/redirect')->getUrl();
+            $controller->getResponse()->setRedirect($redirectUrl);
+        }
+
         $payload = array(
             'controller_action'  => $controller,
             'recaptcha_response' => $response
         );
-        
+
         Mage::dispatchEvent('studioforty9_recaptcha_failed', $payload);
         Mage::dispatchEvent('studioforty9_recaptcha_failed_' . $route, $payload);
-				
+
         return $controller;
     }
     

--- a/app/code/community/Studioforty9/Recaptcha/Model/Source/Version.php
+++ b/app/code/community/Studioforty9/Recaptcha/Model/Source/Version.php
@@ -9,11 +9,15 @@ final class Studioforty9_Recaptcha_Model_Source_Version
      *
      * @return array
      */
-    public function toOptionArray()
+    public function toOptionArray(): array
     {
-        return array(
-            array('value' => 2, 'label'=>Mage::helper('studioforty9_recaptcha')->__('v2')),
-            array('value' => 3, 'label'=>Mage::helper('studioforty9_recaptcha')->__('v3')),
+        $array = $this->toArray();
+        return array_map(
+            static function (string $value, string $label) {
+                return ['value' => $value, 'label' => $label];
+            },
+            array_keys($array),
+            $array
         );
     }
 
@@ -22,11 +26,11 @@ final class Studioforty9_Recaptcha_Model_Source_Version
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
-        return array(
-            2 => Mage::helper('studioforty9_recaptcha')->__('v2'),
-            3 => Mage::helper('studioforty9_recaptcha')->__('v3'),
-        );
+        return [
+            '2' => Mage::helper('studioforty9_recaptcha')->__('v2'),
+            '3' => Mage::helper('studioforty9_recaptcha')->__('v3'),
+        ];
     }
 }

--- a/app/code/community/Studioforty9/Recaptcha/Model/Source/Version.php
+++ b/app/code/community/Studioforty9/Recaptcha/Model/Source/Version.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+final class Studioforty9_Recaptcha_Model_Source_Version
+{
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return array(
+            array('value' => 2, 'label'=>Mage::helper('studioforty9_recaptcha')->__('v2')),
+            array('value' => 3, 'label'=>Mage::helper('studioforty9_recaptcha')->__('v3')),
+        );
+    }
+
+    /**
+     * Get options in "key-value" format
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            2 => Mage::helper('studioforty9_recaptcha')->__('v2'),
+            3 => Mage::helper('studioforty9_recaptcha')->__('v3'),
+        );
+    }
+}

--- a/app/code/community/Studioforty9/Recaptcha/etc/config.xml
+++ b/app/code/community/Studioforty9/Recaptcha/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <Studioforty9_Recaptcha>
-            <version>1.5.7</version>
+            <version>1.5.10</version>
         </Studioforty9_Recaptcha>
     </modules>
     <global>
@@ -144,9 +144,11 @@
                 <enabled_reviews>0</enabled_reviews>
                 <enabled_sendfriend>0</enabled_sendfriend>
                 <enabled_customer_registration>0</enabled_customer_registration>
+                <version>2</version>
                 <site_key></site_key>
                 <secret_key></secret_key>
                 <theme>light</theme>
+                <score_threshold>0.5</score_threshold>
                 <enabled_routes><![CDATA[]]></enabled_routes>
             </recaptcha>
         </google>

--- a/app/code/community/Studioforty9/Recaptcha/etc/config.xml
+++ b/app/code/community/Studioforty9/Recaptcha/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <Studioforty9_Recaptcha>
-            <version>1.5.10</version>
+            <version>1.6.0</version>
         </Studioforty9_Recaptcha>
     </modules>
     <global>

--- a/app/code/community/Studioforty9/Recaptcha/etc/system.xml
+++ b/app/code/community/Studioforty9/Recaptcha/etc/system.xml
@@ -53,6 +53,16 @@
                             <comment><![CDATA[<a href="https://www.google.com/recaptcha/admin" target="_blank">Create a secret key</a>]]></comment>
                             <depends><enabled>1</enabled></depends>
                         </secret_key>
+                        <version>
+                            <label>Version</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>studioforty9_recaptcha/source_version</source_model>
+                            <sort_order>35</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <validate>required-entry</validate>
+                        </version>
                         <theme translate="label">
                             <label>Theme</label>
                             <frontend_type>select</frontend_type>
@@ -62,7 +72,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment><![CDATA[See the Google reCAPTCHA Documentation <a href="https://developers.google.com/recaptcha/docs/display#render_param" target="_blank">for more</a>]]></comment>
-                            <depends><enabled>1</enabled></depends>
+                            <depends><enabled>1</enabled><version>2</version></depends>
                         </theme>
                         <type translate="label">
                             <label>Type</label>
@@ -73,7 +83,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment><![CDATA[See the Google reCAPTCHA Documentation <a href="https://developers.google.com/recaptcha/docs/display#render_param" target="_blank">for more</a>]]></comment>
-                            <depends><enabled>1</enabled></depends>
+                            <depends><enabled>1</enabled><version>2</version></depends>
                         </type>
                         <size translate="label">
                             <label>Size</label>
@@ -84,8 +94,19 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment><![CDATA[See the Google reCAPTCHA Documentation <a href="https://developers.google.com/recaptcha/docs/display#render_param" target="_blank">for more</a>]]></comment>
-                            <depends><enabled>1</enabled></depends>
+                            <depends><enabled>1</enabled><version>2</version></depends>
                         </size>
+                        <score_threshold>
+                            <label>Score Threshold</label>
+                            <comment><![CDATA[Google reCaptcha v3 returns a "score" between 0 and 1 for each request (1.0 is very likely a good interaction, 0.0 is very likely a bot). Here you should configure the score threshold from which consider the interaction a bot. Default value is 0.5. For more info see <a href="https://developers.google.com/recaptcha/docs/v3#interpreting_the_score">the documentation</a>.]]></comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>45</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <validate>required-entry validate-number validate-number-range number-range-0-1</validate>
+                            <depends><enabled>1</enabled><version>3</version></depends>
+                        </score_threshold>
                         <enabled_routes translate="label hint">
                             <label>Enabled Routes</label>
                             <frontend_type>multiselect</frontend_type>

--- a/app/design/frontend/base/default/layout/studioforty9_recaptcha.xml
+++ b/app/design/frontend/base/default/layout/studioforty9_recaptcha.xml
@@ -31,9 +31,9 @@
             <block type="core/text_list" name="form.additional.info">
                 <block type="studioforty9_recaptcha/explicit" name="studioforty9.recaptcha.explicit" template="studioforty9/recaptcha/explicit.phtml"/>
             </block>
-        </reference>  
+        </reference>
     </customer_account_login>
-    
+
     <customer_account_forgotpassword>
         <reference name="forgotPassword">
             <block type="core/text_list" name="form.additional.info">
@@ -41,7 +41,7 @@
             </block>
         </reference>
     </customer_account_forgotpassword>
-    
+
     <customer_account_create>
         <reference name="customer_form_register">
             <block type="core/text_list" name="form.additional.info">

--- a/app/design/frontend/base/default/template/studioforty9/recaptcha/explicit.phtml
+++ b/app/design/frontend/base/default/template/studioforty9/recaptcha/explicit.phtml
@@ -13,27 +13,28 @@
  */
 $id = $this->getRecaptchaId();
 ?>
-<?php if ($this->isAllowed($this->getAction()->getFullActionName())): ?>
+<?php if ($this->isAllowed($this->getAction()->getFullActionName())): ?> 
 
-<div class="recaptcha" style="overflow:hidden;position:relative;margin-bottom:10px;">
-    <input type="checkbox" id="cb-<?php echo $id ?>" name="cb-<?php echo $id ?>" value="" class="required-entry" style="visibility:hidden; position:absolute; left:-1000000px" />
-    <div id="el-<?php echo $id ?>"></div>
-    <script type="text/javascript">
-        var onloadCallback = function() {
-            grecaptcha.render('el-<?php echo $id ?>', {
-                'sitekey': "<?php echo $this->getSiteKey(); ?>",
-                'theme': "<?php echo $this->getTheme(); ?>",
-                'type': "<?php echo $this->getType(); ?>",
-                'size': "<?php echo $this->getSize(); ?>",
-                'callback': function(response) {
-                    if (response.length > 0) {
-                        $('cb-<?php echo $id ?>').writeAttribute('value', 'checked');
-                        $('cb-<?php echo $id ?>').checked = true;
-                    }
-                }
-            });
-        };
-    </script>
-    <?php echo $this->getRecaptchaScript(); ?>
-</div>
+    <div class="recaptcha" style="overflow:hidden;position:relative;margin-bottom:10px;">
+        <input type="checkbox" id="cb-<?php echo $id ?>" name="cb-<?php echo $id ?>" value="" class="required-entry" style="visibility:hidden; position:absolute; left:-1000000px" />
+        <div id="el-<?php echo $id ?>"></div>
+        <?php echo $this->getRecaptchaScript($id); ?>
+    </div>
 <?php endif; ?>
+
+<script type="text/javascript">
+    function onloadCallback<?php echo $id ?>(){
+        ReCaptchaRender = grecaptcha.render('el-<?php echo $id ?>', {
+            'sitekey': "<?php echo $this->getSiteKey(); ?>",
+            'theme': "<?php echo $this->getTheme(); ?>",
+            'type': "<?php echo $this->getType(); ?>",
+            'size': "<?php echo $this->getSize(); ?>",
+            'callback': function (response) {
+                if (response.length > 0) {
+                    $('cb-<?php echo $id ?>').writeAttribute('value', 'checked');
+                    $('cb-<?php echo $id ?>').checked = true;
+                }
+            }
+        });
+    };
+</script>

--- a/app/design/frontend/base/default/template/studioforty9/recaptcha/v3.phtml
+++ b/app/design/frontend/base/default/template/studioforty9/recaptcha/v3.phtml
@@ -25,7 +25,6 @@
         window['recaptchaOnloadCallback_<?= $id ?>_done'] = false;
         window['recaptchaOnloadCallback_<?= $id ?>'] = function() {
             addEventListener('submit', function(e) {
-                alert('recaptcha');
                 var element = document.querySelector('#el-<?= $id ?>');
                 var form = element.form;
                 if (e.target !== form) {
@@ -35,7 +34,6 @@
                     e.preventDefault(); // stop form submit
                     e.stopPropagation(); // stop also events
                     grecaptcha.execute('<?= $this->getSiteKey() ?>', { action: 'submit' }).then(function (token) {
-                        alert('recaptcha promise');
                         element.value = token;
                         window['recaptchaOnloadCallback_<?= $id ?>_done'] = true;
                         if (e.submitter) {

--- a/app/design/frontend/base/default/template/studioforty9/recaptcha/v3.phtml
+++ b/app/design/frontend/base/default/template/studioforty9/recaptcha/v3.phtml
@@ -22,20 +22,31 @@
         var form = element.form;
 
         // recaptcha callback for this form
+        window['recaptchaOnloadCallback_<?= $id ?>_done'] = false;
         window['recaptchaOnloadCallback_<?= $id ?>'] = function() {
-            requestAnimationFrame(function () {
-                Event.observe(form, 'submit', function (e) {
-                    if (e.stopped) {
-                        return;
-                    }
-
-                    e.preventDefault();
-                    grecaptcha.execute('<?= $this->getSiteKey() ?>', {action: 'submit'}).then(function (token) {
+            addEventListener('submit', function(e) {
+                alert('recaptcha');
+                var element = document.querySelector('#el-<?= $id ?>');
+                var form = element.form;
+                if (e.target !== form) {
+                    return
+                }
+                if (!window['recaptchaOnloadCallback_<?= $id ?>_done']) {
+                    e.preventDefault(); // stop form submit
+                    e.stopPropagation(); // stop also events
+                    grecaptcha.execute('<?= $this->getSiteKey() ?>', { action: 'submit' }).then(function (token) {
+                        alert('recaptcha promise');
                         element.value = token;
-                        form.submit();
+                        window['recaptchaOnloadCallback_<?= $id ?>_done'] = true;
+                        if (e.submitter) {
+                            e.submitter.click(); // trigger also events
+                        } else {
+                            form.submit();
+                        }
+                        window['recaptchaOnloadCallback_<?= $id ?>_done'] = false;
                     });
-                });
-            });
+                }
+            }, true) // execute before other submit listeners
         };
 
         // recaptcha load for this form

--- a/app/design/frontend/base/default/template/studioforty9/recaptcha/v3.phtml
+++ b/app/design/frontend/base/default/template/studioforty9/recaptcha/v3.phtml
@@ -1,0 +1,71 @@
+<?php /** @var Studioforty9_Recaptcha_Block_Explicit $this */?>
+<?php $id = $this->getRecaptchaId(); ?>
+<?php $siteKey = $this->getSiteKey(); ?>
+
+<div class="recaptcha">
+    <input type="hidden" id="el-<?= $id ?>" name="<?= Studioforty9_Recaptcha_Helper_Request::REQUEST_RESPONSE ?>" />
+    <style>.grecaptcha-badge { visibility: hidden; }</style>
+    <p>
+        <?=
+            $this->__(
+                'This site is protected by reCAPTCHA and the Google <a href="%s">Privacy Policy</a> and <a href="%s">Terms of Service</a> apply.',
+                'https://policies.google.com/privacy',
+                'https://policies.google.com/terms'
+            )
+        ?>
+    </p>
+</div>
+
+<script>
+    (function(){
+        var element = document.querySelector('#el-<?= $id ?>');
+        var form = element.form;
+
+        // recaptcha callback for this form
+        window['recaptchaOnloadCallback_<?= $id ?>'] = function() {
+            requestAnimationFrame(function () {
+                Event.observe(form, 'submit', function (e) {
+                    if (e.stopped) {
+                        return;
+                    }
+
+                    e.preventDefault();
+                    grecaptcha.execute('<?= $this->getSiteKey() ?>', {action: 'submit'}).then(function (token) {
+                        element.value = token;
+                        form.submit();
+                    });
+                });
+            });
+        };
+
+        // recaptcha load for this form
+
+        var loadJS = function () {
+            //var script = <?= json_encode($this->getRecaptchaScript($id)) ?>;
+            var script = document.createElement('script');
+            script.type = 'text/javascript';
+            script.src = 'https://www.google.com/recaptcha/api.js?render=<?= $this->getSiteKey() ?>&onload=recaptchaOnloadCallback_<?= $id ?>';
+            script.async = true;
+            document.body.appendChild(script);
+        };
+
+        // detect when form is visible
+
+        if (!('IntersectionObserver' in window) ||
+            !('IntersectionObserverEntry' in window) ||
+            !('intersectionRatio' in window.IntersectionObserverEntry.prototype)) {
+            loadJS();
+        } else {
+            var observer = new IntersectionObserver(function(entries, observer) {
+                entries.forEach(function(entry) {
+                    if (entry.intersectionRatio > 0) {
+                        observer.disconnect();
+                        loadJS();
+                    }
+                });
+            }, { root: null });
+
+            observer.observe(form);
+        }
+    })();
+</script>

--- a/app/design/frontend/base/default/template/studioforty9/recaptcha/v3.phtml
+++ b/app/design/frontend/base/default/template/studioforty9/recaptcha/v3.phtml
@@ -41,10 +41,9 @@
         // recaptcha load for this form
 
         var loadJS = function () {
-            //var script = <?= json_encode($this->getRecaptchaScript($id)) ?>;
             var script = document.createElement('script');
             script.type = 'text/javascript';
-            script.src = 'https://www.google.com/recaptcha/api.js?render=<?= $this->getSiteKey() ?>&onload=recaptchaOnloadCallback_<?= $id ?>';
+            script.src = <?= json_encode($this->getRecaptchaV3ScriptUrl()) ?>;
             script.async = true;
             document.body.appendChild(script);
         };

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     }
   ],
   "require": {
-    "magento-hackathon/magento-composer-installer": "*"
+    "magento-hackathon/magento-composer-installer": "*",
+    "google/recaptcha": "^1.2"
   }
 }


### PR DESCRIPTION
Without this change, if you define a custom template in layout it will not be used. Of course you could simply rewrite the module phtml (explicit.phtm or v3.phtml, depending on recaptcha version) but in this case you should make it clear that passing a template in layout will always be ignored.